### PR TITLE
Update _layout.jsx for StatusBar error

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -9,7 +9,10 @@ export default function RootLayout() {
 
   return (
     <>
-      <StatusBar value="auto" />
+      
+      //StatusBar dont  accept "value"
+      
+      <StatusBar style="auto" />
       <Stack screenOptions={{
         headerStyle: { backgroundColor: theme.navBackground },
         headerTintColor: theme.title,


### PR DESCRIPTION
But since you're importing StatusBar from expo-status-bar, the correct prop is:  

<StatusBar style="auto" />